### PR TITLE
Add server Swift basic "HTTP" module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,12 @@ rocket:
 	ln -s -f ../rust/rocket/target/release/server_rust_rocket bin/.
 
 # --- Swift ---
-swift: vapor perfect kitura
+swift: http vapor perfect kitura
+
+# HTTP
+http:
+	cd swift/http; swift build --configuration release
+	ln -s -f ../swift/http/.build/release/server_swift_http bin/.
 
 # Vapor
 vapor:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ CPU Cores: 8
    - [Vapor](https://vapor.codes)
    - [Perfect](https://www.perfect.org)
    - [Kitura](http://www.kitura.io)
+   - [HTTP](https://swift-server.github.io/http/)
  - Scala
    - [Akka-Http (Routing DSL)](http://doc.akka.io/docs/akka-http/current/scala/http/introduction.html#routing-dsl-for-http-servers)
  - C#

--- a/swift/http/Package.swift
+++ b/swift/http/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "server_swift_http",
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(url: "https://github.com/swift-server/http", .upToNextMinor(from: "0.1.0")),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "server_swift_http",
+            dependencies: ["HTTP"]),
+    ]
+)

--- a/swift/http/Sources/server_swift_http/main.swift
+++ b/swift/http/Sources/server_swift_http/main.swift
@@ -1,0 +1,48 @@
+import HTTP
+import Foundation
+
+
+
+let server = HTTPServer()
+
+class WebApp: HTTPRequestHandling {
+    func handle(request: HTTPRequest, response: HTTPResponseWriter ) -> HTTPBodyProcessing {
+
+        switch request.method {
+        case HTTPMethod.get:
+            // GET '/' return status code 200 with empty body
+            if request.target == "/" {
+                response.writeHeader(status: .ok, headers: [.contentLength: "0"])
+                return .discardBody
+            }
+            // GET '/user/:id' return status code 200 with the id
+            else {
+                let idIndex = request.target.index(request.target.startIndex, offsetBy: 6)
+                let user = request.target[..<idIndex]
+                if user == "/user/" {
+                    let result = request.target[idIndex...]
+                    let data = Data(result.utf8)
+                    response.writeHeader(status: .ok, headers: [.contentLength: "\(data.count)"])
+                    response.writeBody(data)
+                    return .discardBody
+                }
+            }
+        case HTTPMethod.post:
+            // POST '/user' return status code 200 with empty body
+            if request.target == "/user" {
+                response.writeHeader(status: .ok, headers: [.contentLength: "0"])
+                return .discardBody
+            }
+        default:
+            response.writeHeader(status: .badRequest)
+            return .discardBody
+        }
+        return .discardBody
+    }
+	
+}
+
+try! server.start(port: 3000, handler: WebApp().handle)
+
+CFRunLoopRun()
+

--- a/tools/src/benchmarker.cr
+++ b/tools/src/benchmarker.cr
@@ -38,6 +38,7 @@ LANGS = [
      {name: "phoenix", repo: "phoenixframework/phoenix"},
    ]},
   {lang: "swift", targets: [
+     {name: "http", bin: "server_swift_http"},
      {name: "vapor", repo: "vapor/vapor"},
      {name: "perfect", repo: "PerfectlySoft/Perfect"},
      {name: "kitura", repo: "IBM-Swift/Kitura"},


### PR DESCRIPTION
Add the Swift Server API projects "HTTP" server to the benchmarks. This is designed to give developers working on the HTTP module a benchmark they can run to check for regressions or to work on optimisations.